### PR TITLE
alignment of parameters between languages, typo fix

### DIFF
--- a/cpp/map_closures/pipeline/MapClosures.hpp
+++ b/cpp/map_closures/pipeline/MapClosures.hpp
@@ -42,7 +42,7 @@ using Tree = srrg_hbst::BinaryTree<Node>;
 
 namespace map_closures {
 struct Config {
-    float density_map_resolution = 0.3;
+    float density_map_resolution = 0.5;
     float density_threshold = 0.05;
     int hamming_distance_threshold = 50;
 };

--- a/python/map_closures/config/parser.py
+++ b/python/map_closures/config/parser.py
@@ -34,7 +34,7 @@ class BaseConfig(BaseModel):
     density_map_resolution: float = 0.5
     density_threshold: float = 0.05
     hamming_distance_threshold: int = 50
-    inliers_threshold: int = 5
+    inliers_threshold: int = 10
     local_map_factor: float = 0.6
 
 

--- a/python/map_closures/tools/cmd.py
+++ b/python/map_closures/tools/cmd.py
@@ -161,7 +161,7 @@ def map_closure_pipeline(
     version: Optional[bool] = typer.Option(
         None,
         "--version",
-        help="Show the current version of KISS-ICP",
+        help="Show the current version of MapClosures",
         callback=version_callback,
         is_eager=True,
     ),


### PR DESCRIPTION
@saurabh1002 Thank you and the PR Bonn team for the nice module in the beloved KISS-ICP style!

On addition to PR https://github.com/PRBonn/MapClosures/pull/3, I would like to submit 2 changes:

- Typo fix in help information
- Alignment of the default parameters of the different language formats, to the provided base-config and the paper.

It could be assumed that the basic_config also corresponds to the default values, which can lead to errors.