### PR TITLE
Use typing_extensions

### DIFF
--- a/python/map_closures/map_closures.py
+++ b/python/map_closures/map_closures.py
@@ -20,7 +20,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from typing import TypeAlias
+from typing_extensions import TypeAlias
 
 import numpy as np
 from pydantic_settings import BaseSettings

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "tqdm",
     "typer[all]>=0.6.0",
     "rich",
+    "typing_extensions",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
To still support Python3.8, we should use the `TypeAlias` from `typing_extensions`.