### PR TITLE
make opencv fetch content-able

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,18 @@ Effectively Detecting Loop Closures using Point Cloud Density Maps.
     ```sh
     sudo apt-get install --no-install-recommends -y build-essential ccache clang-format git cmake pybind11-dev python3-dev python3-pip
     ```
-- Eigen
-    ```sh
-    sudo apt-get install libeigen3-dev
-    ```
-- OpenCV
-    ```sh
-    git clone --depth 1 https://github.com/opencv/opencv.git -b 4.x
-    cd opencv && mkdir build && cd build
-    cmake .. && make -j$(nproc --all) && make install
-    ```
+
+- Optional. If the following are installed on your system, they will be used (faster build). Otherwise, they will be built alongside MapClosures.
+  - Eigen
+      ```sh
+      sudo apt-get install libeigen3-dev
+      ```
+  - OpenCV
+      ```sh
+      git clone --depth 1 https://github.com/opencv/opencv.git -b 4.x
+      cd opencv && mkdir build && cd build
+      cmake .. && make -j$(nproc --all) && make install
+      ```
 ### MapClosures
 ```sh
 git clone https://github.com/PRBonn/MapClosures.git

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Effectively Detecting Loop Closures using Point Cloud Density Maps.
     sudo apt-get install --no-install-recommends -y build-essential cmake pybind11-dev python3-dev python3-pip
     ```
 
-- *Optionally Built* 
+- *Optionally Built* \
   In this case you have two options:
   - **Option 1**: You can install them by the package manager in your operative system, e.g. in Ubuntu 22.04:
       ```sh

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Effectively Detecting Loop Closures using Point Cloud Density Maps.
     sudo apt-get install --no-install-recommends -y build-essential cmake pybind11-dev python3-dev python3-pip
     ```
 
-- *Optionally Built* In this case you have two options:
+- *Optionally Built* 
+  In this case you have two options:
   - **Option 1**: You can install them by the package manager in your operative system, e.g. in Ubuntu 22.04:
       ```sh
       sudo apt-get install libeigen3-dev libopencv-dev libtbb-dev

--- a/README.md
+++ b/README.md
@@ -34,12 +34,7 @@ Effectively Detecting Loop Closures using Point Cloud Density Maps.
     ```sh
     sudo apt-get install libeigen3-dev
     ```
-- OpenCV
-    ```sh
-    git clone --depth 1 https://github.com/opencv/opencv.git -b 4.x
-    cd opencv && mkdir build && cd build
-    cmake .. && make -j$(nproc --all) && make install
-    ```
+- If OpenCV is installed on your system, it is used during the build. Otherwise, the necessary OpenCV modules are built alongside MapClosures.
 ### MapClosures
 ```sh
 git clone https://github.com/PRBonn/MapClosures.git

--- a/README.md
+++ b/README.md
@@ -34,7 +34,12 @@ Effectively Detecting Loop Closures using Point Cloud Density Maps.
     ```sh
     sudo apt-get install libeigen3-dev
     ```
-- If OpenCV is installed on your system, it is used during the build. Otherwise, the necessary OpenCV modules are built alongside MapClosures.
+- OpenCV
+    ```sh
+    git clone --depth 1 https://github.com/opencv/opencv.git -b 4.x
+    cd opencv && mkdir build && cd build
+    cmake .. && make -j$(nproc --all) && make install
+    ```
 ### MapClosures
 ```sh
 git clone https://github.com/PRBonn/MapClosures.git

--- a/README.md
+++ b/README.md
@@ -28,20 +28,20 @@ Effectively Detecting Loop Closures using Point Cloud Density Maps.
 ### Dependencies
 - Essentials
     ```sh
-    sudo apt-get install --no-install-recommends -y build-essential ccache clang-format git cmake pybind11-dev python3-dev python3-pip
+    sudo apt-get install --no-install-recommends -y build-essential cmake pybind11-dev python3-dev python3-pip
     ```
 
-- Optional. If the following are installed on your system, they will be used (faster build). Otherwise, they will be built alongside MapClosures.
-  - Eigen
+- Optionally Built: In this case you have two options:
+  - **Option 1**: You can install them by the package manager in your operative system, e.g. in Ubuntu 22.04:
       ```sh
-      sudo apt-get install libeigen3-dev
+      sudo apt-get install libeigen3-dev libopencv-dev libtbb-dev
       ```
-  - OpenCV
+      this will of course make the build of **MapClosures** much faster.
+  - **Option 2**: Let the build system handle them:
       ```sh
-      git clone --depth 1 https://github.com/opencv/opencv.git -b 4.x
-      cd opencv && mkdir build && cd build
-      cmake .. && make -j$(nproc --all) && make install
+      cmake -B build -S cpp -DUSE_SYSTEM_TBB=OFF -DUSE_SYSTEM_OPENCV=OFF -DUSE_SYSTEM_EIGEN3=OFF
       ```
+      this will be slower in terms of build time, but will enable you to have a different version of this library installed in your system without interfering with the build of **MapClosures**.
 ### MapClosures
 ```sh
 git clone https://github.com/PRBonn/MapClosures.git

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ Effectively Detecting Loop Closures using Point Cloud Density Maps.
 ## Install
 
 ### Dependencies
-- Essentials
+- *Essentials*
     ```sh
     sudo apt-get install --no-install-recommends -y build-essential cmake pybind11-dev python3-dev python3-pip
     ```
 
-- Optionally Built: In this case you have two options:
+- *Optionally Built* In this case you have two options:
   - **Option 1**: You can install them by the package manager in your operative system, e.g. in Ubuntu 22.04:
       ```sh
       sudo apt-get install libeigen3-dev libopencv-dev libtbb-dev
@@ -41,15 +41,20 @@ Effectively Detecting Loop Closures using Point Cloud Density Maps.
       ```sh
       cmake -B build -S cpp -DUSE_SYSTEM_TBB=OFF -DUSE_SYSTEM_OPENCV=OFF -DUSE_SYSTEM_EIGEN3=OFF
       ```
-      this will be slower in terms of build time, but will enable you to have a different version of this library installed in your system without interfering with the build of **MapClosures**.
-### MapClosures
+      this will be slower in terms of build time, but will enable you to have a different version of this libraries installed in your system without interfering with the build of **MapClosures**.
+
+Once the dependencies are installed, the C++ library can be build by using standard cmake commands:
 ```sh
-git clone https://github.com/PRBonn/MapClosures.git
-cd MapClosures
-make
+cmake -B build -S cpp
+cmake --build build -j8
 ```
 
-## Usage
+## Python Package
+We provide a _python_ wrapper for **MapClosures** which can be easily installed by simply running:
+```sh
+make
+```
+### Usage
 <details>
 <summary>
 The following command will provide details about how to use our pipeline:

--- a/cpp/3rdparty/eigen/eigen.cmake
+++ b/cpp/3rdparty/eigen/eigen.cmake
@@ -1,7 +1,6 @@
 # MIT License
-#
-# Copyright (c) 2024 Saurabh Gupta, Tiziano Guadagnino, Benedikt Mersch,
-# Ignacio Vizzo, Cyrill Stachniss.
+# Copyright (c) 2022 Ignacio Vizzo, Tiziano Guadagnino, Benedikt Mersch, Cyrill
+# Stachniss.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -29,5 +28,15 @@ set(EIGEN_BUILD_LAPACK OFF CACHE BOOL "Don't build lapack module")
 
 include(FetchContent)
 FetchContent_Declare(eigen GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git GIT_TAG 3.4.0)
-FetchContent_Populate(eigen)
-add_subdirectory(${eigen_SOURCE_DIR} ${eigen_BINARY_DIR} SYSTEM EXCLUDE_FROM_ALL)
+if(NOT eigen_POPULATED)
+  FetchContent_Populate(eigen)
+  if(${CMAKE_VERSION} GREATER_EQUAL 3.25)
+    add_subdirectory(${eigen_SOURCE_DIR} ${eigen_BINARY_DIR} SYSTEM EXCLUDE_FROM_ALL)
+  else()
+    # Emulate the SYSTEM flag introduced in CMake 3.25. Withouth this flag the compiler will
+    # consider this 3rdparty headers as source code and fail due the -Werror flag.
+    add_subdirectory(${eigen_SOURCE_DIR} ${eigen_BINARY_DIR} EXCLUDE_FROM_ALL)
+    get_target_property(eigen_include_dirs eigen INTERFACE_INCLUDE_DIRECTORIES)
+    set_target_properties(eigen PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${eigen_include_dirs}")
+  endif()
+endif()

--- a/cpp/3rdparty/find_dependencies.cmake
+++ b/cpp/3rdparty/find_dependencies.cmake
@@ -37,4 +37,19 @@ if(NOT TARGET TBB::tbb)
   include(${CMAKE_CURRENT_LIST_DIR}/tbb/tbb.cmake)
 endif()
 
+if(${USE_SYSTEM_OPENCV})
+  find_package(OpenCV QUIET NO_MODULE)
+endif()
+if(NOT TARGET opencv_features2d)
+  include(${CMAKE_CURRENT_LIST_DIR}/opencv/opencv.cmake)
+endif()
+# Taken from an issue in the OpenCV project (https://github.com/opencv/opencv/issues/20548#issuecomment-1325751099)
+add_library(OpenCV4 INTERFACE)
+target_link_libraries(OpenCV4 INTERFACE opencv_core opencv_features2d opencv_imgproc)
+target_include_directories(
+  OpenCV4
+  INTERFACE ${OPENCV_CONFIG_FILE_INCLUDE_DIR} ${OPENCV_MODULE_opencv_core_LOCATION}/include
+            ${OPENCV_MODULE_opencv_features2d_LOCATION}/include
+            ${OPENCV_MODULE_opencv_imgproc_LOCATION}/include ${OpenCV_INCLUDE_DIRS})
+
 include(${CMAKE_CURRENT_LIST_DIR}/hbst/hbst.cmake)

--- a/cpp/3rdparty/find_dependencies.cmake
+++ b/cpp/3rdparty/find_dependencies.cmake
@@ -44,5 +44,4 @@ find_dependecy("Eigen3" "Eigen3::Eigen" "${CMAKE_CURRENT_LIST_DIR}/eigen/eigen.c
 find_dependecy("TBB" "TBB::tbb" "${CMAKE_CURRENT_LIST_DIR}/tbb/tbb.cmake")
 find_dependecy("OpenCV" "opencv_features2d" "${CMAKE_CURRENT_LIST_DIR}/opencv/opencv.cmake")
 
-
 include(${CMAKE_CURRENT_LIST_DIR}/hbst/hbst.cmake)

--- a/cpp/3rdparty/opencv/LICENSE
+++ b/cpp/3rdparty/opencv/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cpp/3rdparty/opencv/opencv.cmake
+++ b/cpp/3rdparty/opencv/opencv.cmake
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2024 Meher Malladi, Tiziano Guadagnino
+# Copyright (c) 2024 Tiziano Guadagnino, Meher Malladi, Saurabh Gupta
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/cpp/3rdparty/opencv/opencv.cmake
+++ b/cpp/3rdparty/opencv/opencv.cmake
@@ -1,0 +1,38 @@
+set(BUILD_opencv_core ON CACHE BOOL "Build OpenCV core module")
+set(BUILD_opencv_features2d ON CACHE BOOL "Build OpenCV features2d module")
+set(BUILD_opencv_imgproc ON CACHE BOOL "Build OpenCV imgproc module")
+
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries")
+set(BUILD_JAVA OFF CACHE BOOL "Build Java bindings")
+set(BUILD_PERF_TESTS OFF CACHE BOOL "Build performance tests")
+set(BUILD_PROTOBUF OFF CACHE BOOL "Build protobuf")
+set(BUILD_TESTS OFF CACHE BOOL "Build tests")
+set(BUILD_opencv_apps OFF CACHE BOOL "Build OpenCV apps")
+set(BUILD_opencv_calib3d OFF CACHE BOOL "Build OpenCV calib3d module")
+set(BUILD_opencv_dnn OFF CACHE BOOL "Build OpenCV DNN module")
+set(BUILD_opencv_flann OFF CACHE BOOL "Build OpenCV flann module")
+set(BUILD_opencv_gapi OFF CACHE BOOL "Build OpenCV G-API")
+set(BUILD_opencv_highgui OFF CACHE BOOL "Build OpenCV HighGUI")
+set(BUILD_opencv_imgcodecs OFF CACHE BOOL "Build OpenCV imgcodecs")
+set(BUILD_opencv_java_bindings_generator OFF CACHE BOOL "Build OpenCV Java bindings generator")
+set(BUILD_opencv_js_bindings_generator OFF CACHE BOOL "Build OpenCV JavaScript bindings generator")
+set(BUILD_opencv_ml OFF CACHE BOOL "Build OpenCV machine learning module")
+set(BUILD_opencv_objc_bindings_generator OFF CACHE BOOL
+                                                   "Build OpenCV Objective-C bindings generator")
+set(BUILD_opencv_objdetect OFF CACHE BOOL "Build OpenCV object detection module")
+set(BUILD_opencv_photo OFF CACHE BOOL "Build OpenCV photo module")
+set(BUILD_opencv_python3 OFF CACHE BOOL "Build OpenCV Python 3 bindings")
+set(BUILD_opencv_python_bindings_generator OFF CACHE BOOL "Build OpenCV Python bindings generator")
+set(BUILD_opencv_python_tests OFF CACHE BOOL "Build OpenCV Python tests")
+set(BUILD_opencv_stitching OFF CACHE BOOL "Build OpenCV stitching module")
+set(BUILD_opencv_video OFF CACHE BOOL "Build OpenCV video module")
+set(BUILD_opencv_videoio OFF CACHE BOOL "Build OpenCV video IO module")
+
+include(FetchContent)
+FetchContent_Declare(opencv URL https://github.com/opencv/opencv/archive/refs/tags/4.9.0.tar.gz
+)# downloading the zip is faster than cloning a repo
+# GIT_REPOSITORY https://github.com/opencv/opencv.git GIT_TAG 4.x GIT_SHALLOW
+# TRUE GIT_PROGRESS TRUE)
+FetchContent_MakeAvailable(opencv)
+# OpenCV_INCLUDE_DIRS is set by OpenCVConfig.cmake and is unavailable after simply building
+set(OpenCV_INCLUDE_DIRS "${opencv_SOURCE_DIR}/include")

--- a/cpp/3rdparty/opencv/opencv.cmake
+++ b/cpp/3rdparty/opencv/opencv.cmake
@@ -1,3 +1,25 @@
+# MIT License
+#
+# Copyright (c) 2024 Meher Malladi, Tiziano Guadagnino
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 set(BUILD_opencv_core ON CACHE BOOL "Build OpenCV core module")
 set(BUILD_opencv_features2d ON CACHE BOOL "Build OpenCV features2d module")
 set(BUILD_opencv_imgproc ON CACHE BOOL "Build OpenCV imgproc module")
@@ -34,3 +56,16 @@ FetchContent_Declare(opencv GIT_REPOSITORY https://github.com/opencv/opencv.git 
 FetchContent_MakeAvailable(opencv)
 # OpenCV_INCLUDE_DIRS is set by OpenCVConfig.cmake and is unavailable after simply building
 set(OpenCV_INCLUDE_DIRS "${opencv_SOURCE_DIR}/include")
+
+add_library(OpenCV INTERFACE)
+target_link_libraries(OpenCV INTERFACE opencv_core opencv_features2d opencv_imgproc)
+# Taken from an issue in the OpenCV project (https://github.com/opencv/opencv/issues/20548#issuecomment-1325751099)
+target_include_directories(
+  OpenCV
+  INTERFACE ${OPENCV_CONFIG_FILE_INCLUDE_DIR} ${OPENCV_MODULE_opencv_core_LOCATION}/include
+            ${OPENCV_MODULE_opencv_features2d_LOCATION}/include
+            ${OPENCV_MODULE_opencv_imgproc_LOCATION}/include ${OpenCV_INCLUDE_DIRS})
+
+# try to hide this madness to the end-user
+set(OpenCV_LIBS OpenCV)
+

--- a/cpp/3rdparty/opencv/opencv.cmake
+++ b/cpp/3rdparty/opencv/opencv.cmake
@@ -29,10 +29,8 @@ set(BUILD_opencv_video OFF CACHE BOOL "Build OpenCV video module")
 set(BUILD_opencv_videoio OFF CACHE BOOL "Build OpenCV video IO module")
 
 include(FetchContent)
-FetchContent_Declare(opencv URL https://github.com/opencv/opencv/archive/refs/tags/4.9.0.tar.gz
-)# downloading the zip is faster than cloning a repo
-# GIT_REPOSITORY https://github.com/opencv/opencv.git GIT_TAG 4.x GIT_SHALLOW
-# TRUE GIT_PROGRESS TRUE)
+FetchContent_Declare(opencv GIT_REPOSITORY https://github.com/opencv/opencv.git GIT_TAG 4.x
+                     GIT_SHALLOW TRUE GIT_PROGRESS TRUE)
 FetchContent_MakeAvailable(opencv)
 # OpenCV_INCLUDE_DIRS is set by OpenCVConfig.cmake and is unavailable after simply building
 set(OpenCV_INCLUDE_DIRS "${opencv_SOURCE_DIR}/include")

--- a/cpp/3rdparty/opencv/opencv.cmake
+++ b/cpp/3rdparty/opencv/opencv.cmake
@@ -60,6 +60,7 @@ set(OpenCV_INCLUDE_DIRS "${opencv_SOURCE_DIR}/include")
 add_library(OpenCV INTERFACE)
 target_link_libraries(OpenCV INTERFACE opencv_core opencv_features2d opencv_imgproc)
 # Taken from an issue in the OpenCV project (https://github.com/opencv/opencv/issues/20548#issuecomment-1325751099)
+# Include files from OpenCV modules are not forwarded to the corresponding targets, so we need to add them manually
 target_include_directories(
   OpenCV
   INTERFACE ${OPENCV_CONFIG_FILE_INCLUDE_DIR} ${OPENCV_MODULE_opencv_core_LOCATION}/include

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -24,10 +24,9 @@
 cmake_minimum_required(VERSION 3.22)
 project(map_closures_cpp VERSION 0.1.0 LANGUAGES CXX)
 
-find_package(OpenCV REQUIRED)
-
 option(USE_SYSTEM_EIGEN3 "Use system pre-installed Eigen" ON)
 option(USE_SYSTEM_TBB "Use system pre-installed TBB" ON)
+option(USE_SYSTEM_OPENCV "Use system pre-installed OpenCV" ON)
 
 set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -26,7 +26,7 @@ project(map_closures_cpp VERSION 0.1.0 LANGUAGES CXX)
 
 option(USE_SYSTEM_EIGEN3 "Use system pre-installed Eigen" ON)
 option(USE_SYSTEM_TBB "Use system pre-installed TBB" ON)
-option(USE_SYSTEM_OPENCV "Use system pre-installed OpenCV" ON)
+option(USE_SYSTEM_OPENCV "Use system pre-installed OpenCV" OFF)
 
 set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -26,7 +26,7 @@ project(map_closures_cpp VERSION 0.1.0 LANGUAGES CXX)
 
 option(USE_SYSTEM_EIGEN3 "Use system pre-installed Eigen" ON)
 option(USE_SYSTEM_TBB "Use system pre-installed TBB" ON)
-option(USE_SYSTEM_OPENCV "Use system pre-installed OpenCV" OFF)
+option(USE_SYSTEM_OPENCV "Use system pre-installed OpenCV" ON)
 
 set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/cpp/map_closures/CMakeLists.txt
+++ b/cpp/map_closures/CMakeLists.txt
@@ -24,5 +24,5 @@
 add_library(map_closures STATIC)
 target_sources(map_closures PRIVATE DensityMap.cpp AlignRansac2D.cpp MapClosures.cpp)
 target_include_directories(map_closures PUBLIC ${hbst_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(map_closures PUBLIC Eigen3::Eigen TBB::tbb OpenCV4)
+target_link_libraries(map_closures PUBLIC Eigen3::Eigen TBB::tbb ${OpenCV_LIBS})
 target_compile_features(map_closures PUBLIC cxx_std_17)

--- a/cpp/map_closures/CMakeLists.txt
+++ b/cpp/map_closures/CMakeLists.txt
@@ -24,5 +24,5 @@
 add_library(map_closures STATIC)
 target_sources(map_closures PRIVATE DensityMap.cpp AlignRansac2D.cpp MapClosures.cpp)
 target_include_directories(map_closures PUBLIC ${hbst_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(map_closures PUBLIC Eigen3::Eigen TBB::tbb ${OpenCV_LIBS})
+target_link_libraries(map_closures PUBLIC Eigen3::Eigen TBB::tbb OpenCV4)
 target_compile_features(map_closures PUBLIC cxx_std_17)

--- a/python/map_closures/map_closures.py
+++ b/python/map_closures/map_closures.py
@@ -23,15 +23,14 @@
 from typing_extensions import TypeAlias
 
 import numpy as np
-from pydantic_settings import BaseSettings
-
+from map_closures.config import MapClosuresConfig
 from map_closures.pybind import map_closures_pybind
 
 ClosureCandidate: TypeAlias = map_closures_pybind._ClosureCandidate
 
 
 class MapClosures:
-    def __init__(self, config: BaseSettings):
+    def __init__(self, config: MapClosuresConfig = MapClosuresConfig()):
         self._config = config
         self._pipeline = map_closures_pybind._MapClosures(self._config.model_dump())
 


### PR DESCRIPTION
Opencv can be fetch content-ed as #6 tried to do.
HBST has a `#include <opencv2/opencv.hpp>` which needs the `OpenCV_INCLUDE_DIRS` to be set manually.
I've disabled a lot of stuff when building opencv, that probably needs a check.