### PR TITLE
Add instructions to use MapClosures C++ API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ Effectively Detecting Loop Closures using Point Cloud Density Maps.
     
 1. Include the following snippet in your project's `CMakeLists.txt`:
 ```cmake
-option(USE_SYSTEM_EIGEN3 ON)
-option(USE_SYSTEM_TBB ON)
-option(USE_SYSTEM_OPENCV ON)
+set(USE_SYSTEM_EIGEN3 ON CACHE BOOL "use system eigen3")
+set(USE_SYSTEM_TBB ON CACHE BOOL "use system tbb")
+set(USE_SYSTEM_OPENCV ON CACHE BOOL "use system opencv")
+
 include(FetchContent)
 FetchContent_Declare(
     map_closures 
@@ -39,7 +40,7 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(map_closures)
 ```
-You can trigger the automatic installation of the dependencies by playing around with the options in the snippet.
+You can trigger the automatic installation of the dependencies by playing around with the options in the first three lines of the snippet.
 
 2. Link **MapClosures** against your library or executable:
 ```cmake
@@ -50,39 +51,19 @@ target_link_libraries(my_target PUBLIC map_closures)
 #include <map_closures/MapClosures.hpp>
 ```
 
-## Install
-
-### Dependencies
-- *Essentials*
+## Install the Python API and CLI 
+1. First, install the necessary system dependencies
     ```sh
-    sudo apt-get install --no-install-recommends -y build-essential cmake pybind11-dev python3-dev python3-pip
-    pip install kiss-icp==0.4.0
+    sudo apt-get install --no-install-recommends -y build-essential cmake pybind11-dev libeigen3-dev libopencv-dev libtbb-dev
     ```
-
-- *Optionally Built* \
-  In this case you have two options:
-  - **Option 1**: You can install them by the package manager in your operative system, e.g. in Ubuntu 22.04:
-      ```sh
-      sudo apt-get install libeigen3-dev libopencv-dev libtbb-dev
-      ```
-      this will of course make the build of **MapClosures** much faster.
-  - **Option 2**: Let the build system handle them:
-      ```sh
-      cmake -B build -S cpp -DUSE_SYSTEM_TBB=OFF -DUSE_SYSTEM_OPENCV=OFF -DUSE_SYSTEM_EIGEN3=OFF
-      ```
-      this will be slower in terms of build time, but will enable you to have a different version of this libraries installed in your system without interfering with the build of **MapClosures**.
-
-Once the dependencies are installed, the C++ library can be build by using standard cmake commands:
-```sh
-cmake -B build -S cpp
-cmake --build build -j8
-```
-
-## Python Package
-We provide a _python_ wrapper for **MapClosures** which can be easily installed by simply running:
-```sh
-make
-```
+2. To get an odometry estimate in our Python CLI we rely on [KISS-ICP](https://github.com/PRBonn/kiss-icp), you can install it using
+    ```sh
+    pip install kiss-icp
+    ```
+3. Then run:  
+    ```sh
+    make
+    ```
 ### Usage
 <details>
 <summary>

--- a/README.md
+++ b/README.md
@@ -23,8 +23,14 @@ Effectively Detecting Loop Closures using Point Cloud Density Maps.
 </div>
 <hr />
 
-## Use MapClosures C++ API as 3rdparty package
-Include the following snippet in your project's `CMakeLists.txt` to access MapClosures C++ API:
+## Guide to MapClosures C++ API
+<details>
+<summary>
+Instructions to use the MapClosures C++ API in your beautiful SLAM pipeline
+</summary>
+</br>
+    
+1. Include the following snippet in your project's `CMakeLists.txt` and link your beautiful C++ library/executable against the MapClosures library:
 ```cmake
 cmake_minimum_required(VERSION 3.18)
 include(FetchContent)
@@ -34,15 +40,15 @@ FetchContent_Declare(
         GIT_TAG main
         SOURCE_SUBDIR cpp
 )
-```
-Now, you can link your beautiful C++ library/executable against the MapClosures library using the following line:
-```cmake
 target_link_libraries(<your-beautiful-library> PUBLIC map_closures)
-```
-and use the following include directive in your source code file to access the core API of MapClosures:
+``` 
+2. The following include directive in your source code file will provide access to the core API of MapClosures:
 ```cpp
 #include "map_closures/MapClosures.hpp"
 ```
+3. The core API functionalities are as shown below:
+![image](https://github.com/user-attachments/assets/f2282b9f-f5ff-4a63-a422-cb2d6e554a6b)
+</details>
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,27 @@ Effectively Detecting Loop Closures using Point Cloud Density Maps.
 </div>
 <hr />
 
+## Use MapClosures C++ API as 3rdparty package
+Include the following snippet in your project's `CMakeLists.txt` to access MapClosures C++ API:
+```cmake
+cmake_minimum_required(VERSION 3.18)
+include(FetchContent)
+FetchContent_Declare(
+    map_closures 
+        GIT_REPOSITORY https://github.com/PRBonn/MapClosures.git
+        GIT_TAG main
+        SOURCE_SUBDIR cpp
+)
+```
+Now, you can link your beautiful C++ library/executable against the MapClosures library using the following line:
+```cmake
+target_link_libraries(<your-beautiful-library> PUBLIC map_closures)
+```
+and use the following include directive in your source code file to access the core API of MapClosures:
+```cpp
+#include "map_closures/MapClosures.hpp"
+```
+
 ## Install
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -23,16 +23,13 @@ Effectively Detecting Loop Closures using Point Cloud Density Maps.
 </div>
 <hr />
 
-## Guide to MapClosures C++ API
-<details>
-<summary>
-Instructions to use the MapClosures C++ API in your beautiful SLAM pipeline
-</summary>
-</br>
+## Use MapClosures in your C++ project
     
-1. Include the following snippet in your project's `CMakeLists.txt` and link your beautiful C++ library/executable against the MapClosures library:
+1. Include the following snippet in your project's `CMakeLists.txt`:
 ```cmake
-cmake_minimum_required(VERSION 3.18)
+option(USE_SYSTEM_EIGEN3 ON)
+option(USE_SYSTEM_TBB ON)
+option(USE_SYSTEM_OPENCV ON)
 include(FetchContent)
 FetchContent_Declare(
     map_closures 
@@ -40,15 +37,18 @@ FetchContent_Declare(
         GIT_TAG main
         SOURCE_SUBDIR cpp
 )
-target_link_libraries(<your-beautiful-library> PUBLIC map_closures)
-``` 
-2. The following include directive in your source code file will provide access to the core API of MapClosures:
-```cpp
-#include "map_closures/MapClosures.hpp"
+FetchContent_MakeAvailable(map_closures)
 ```
-3. The core API functionalities are as shown below:
-![image](https://github.com/user-attachments/assets/f2282b9f-f5ff-4a63-a422-cb2d6e554a6b)
-</details>
+You can trigger the automatic installation of the dependencies by playing around with the options in the snippet.
+
+2. Link **MapClosures** against your library or executable:
+```cmake
+target_link_libraries(my_target PUBLIC map_closures)
+```
+3. The following _include_ directive in your source code file will provide access to the core API of MapClosures:
+```cpp
+#include <map_closures/MapClosures.hpp>
+```
 
 ## Install
 

--- a/cpp/map_closures/CMakeLists.txt
+++ b/cpp/map_closures/CMakeLists.txt
@@ -23,9 +23,6 @@
 
 add_library(map_closures STATIC)
 target_sources(map_closures PRIVATE DensityMap.cpp AlignRansac2D.cpp MapClosures.cpp)
-target_include_directories(
-  map_closures
-  PUBLIC ${hbst_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/.. $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+target_include_directories(map_closures PUBLIC ${hbst_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(map_closures PUBLIC Eigen3::Eigen TBB::tbb ${OpenCV_LIBS})
 target_compile_features(map_closures PUBLIC cxx_std_17)

--- a/cpp/map_closures/CMakeLists.txt
+++ b/cpp/map_closures/CMakeLists.txt
@@ -23,6 +23,9 @@
 
 add_library(map_closures STATIC)
 target_sources(map_closures PRIVATE DensityMap.cpp AlignRansac2D.cpp MapClosures.cpp)
-target_include_directories(map_closures PUBLIC ${hbst_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_include_directories(
+  map_closures
+  PUBLIC ${hbst_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/.. $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_link_libraries(map_closures PUBLIC Eigen3::Eigen TBB::tbb ${OpenCV_LIBS})
 target_compile_features(map_closures PUBLIC cxx_std_17)


### PR DESCRIPTION
This PR provides the instructions to include the MapClosures C++ API in a custom Project through CMake FetchContent.