### PR TITLE
Fix bug in closure candidate indices

### DIFF
--- a/cpp/map_closures/MapClosures.cpp
+++ b/cpp/map_closures/MapClosures.cpp
@@ -29,7 +29,6 @@
 #include <Eigen/Core>
 #include <algorithm>
 #include <cmath>
-#include <map>
 #include <opencv2/core.hpp>
 #include <utility>
 #include <vector>
@@ -79,7 +78,8 @@ ClosureCandidate MapClosures::MatchAndAdd(const int id,
                                    srrg_hbst::SplittingStrategy::SplitEven);
     density_maps_.emplace(id, std::move(density_map));
     std::vector<int> indices(descriptor_matches_.size());
-    std::iota(indices.begin(), indices.end(), 0);
+    std::transform(descriptor_matches_.cbegin(), descriptor_matches_.cend(), indices.begin(),
+                   [](const auto &descriptor_match) { return descriptor_match.first; });
     auto compare_closure_candidates = [](ClosureCandidate a,
                                          const ClosureCandidate &b) -> ClosureCandidate {
         return a.number_of_inliers > b.number_of_inliers ? a : b;


### PR DESCRIPTION
1. This fixes a bug we had in the way we looped over an unordered_map of candidate closure indices
2. This bug appeared only in extreme edge cases, like when testing on challenging data from the forests.
3. Does not affect the performance of the already supported sequences from the corresponding paper