### PR TITLE
add global view option to local map visualizer

### DIFF
--- a/python/map_closures/visualizer/local_maps_visualizer.py
+++ b/python/map_closures/visualizer/local_maps_visualizer.py
@@ -46,6 +46,7 @@ class LocalMapVisualizer:
         self.view_local_map = True
         self.local_map_id: int = 0
         self.toggle_view: bool = False
+        self.global_view: bool = False
         self.view_density_map: bool = False
         self.local_map_points_size: float = PTS_SIZE
 
@@ -94,7 +95,11 @@ class LocalMapVisualizer:
             color=LOCAL_MAP_COLOR,
             point_render_mode="quad",
         )
-        local_map.set_transform(I)
+        if self.global_view:
+            local_map_pose = self.localmap_data.local_map_poses[self.local_map_id]
+            local_map.set_transform(local_map_pose)
+        else:
+            local_map.set_transform(I)
         local_map.set_enabled(self.view_local_map)
         local_map.set_radius(self.local_map_points_size, relative=False)
         if self.view_density_map:

--- a/python/map_closures/visualizer/visualizer.py
+++ b/python/map_closures/visualizer/visualizer.py
@@ -142,9 +142,8 @@ class Visualizer(StubVisualizer):
         self._gui.Separator()
         self._background_color_callback()
         self._gui.Separator()
-        if not self.local_maps.toggle_view:
-            self._global_view_callback()
-            self._gui.SameLine()
+        self._global_view_callback()
+        self._gui.SameLine()
         self._center_viewpoint_callback()
         self._gui.SameLine()
         self._quit_callback()
@@ -205,8 +204,6 @@ class Visualizer(StubVisualizer):
                 self.local_maps._update_callback()
                 if self.local_maps.view_density_map:
                     self.local_maps.matplotlib_eventloop()
-                if self.global_view:
-                    self._unregister_trajectory()
             else:
                 self.registration.states.view_frame = True
                 self.registration.states.view_local_map = True
@@ -219,8 +216,6 @@ class Visualizer(StubVisualizer):
                 if self.local_maps.view_density_map:
                     self.local_maps.view_density_map = False
                     self.local_maps.close_density_map_fig()
-                if self.global_view:
-                    self._register_trajectory()
 
     def _switch_to_closures_view_callback(self):
         BUTTON_NAME = REGISTRATION_VIEW_2 if self.closures.states.toggle_view else CLOSURES_VIEW
@@ -269,6 +264,7 @@ class Visualizer(StubVisualizer):
             self.global_view = not self.global_view
             self.registration.states.global_view = self.global_view
             self.closures.states.global_view = self.global_view
+            self.local_maps.global_view = self.global_view
             if self.global_view:
                 self._ps.get_point_cloud("source").set_transform(self.registration.last_frame_pose)
                 self._ps.get_point_cloud("target").set_transform(I)


### PR DESCRIPTION
The current visualizer for local maps only supports local view.

This PR adds the global view option to the local map visualizer, which aligns each local map to the global trajectory obtained from the odometry. This is useful to visualize data in relation to their location within the scanned area.