### PR TITLE
Add Git attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.cpp linguist-language=C++
+*.hpp linguist-language=C++
+*.md linguist-documentation
+*.py linguist-vendored
+*.ipynb linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,3 @@
 *.hpp linguist-language=C++
 *.md linguist-documentation
 *.py linguist-vendored
-*.ipynb linguist-vendored


### PR DESCRIPTION
This ensures that GitHub classifies the project as a C++ project (not python). This is more consistent with how me and @saurabh1002 view the project, so we should just do it.