### PR TITLE
Fix for Saving Evaluation Metrics in Loop Closure Pipeline

### DIFF
--- a/python/map_closures/pipeline.py
+++ b/python/map_closures/pipeline.py
@@ -105,10 +105,10 @@ class MapClosurePipeline:
 
     def run(self):
         self._run_pipeline()
+        self.results.compute_closures_and_metrics()
         self._save_config()
         self._log_to_file()
         self._log_to_console()
-        self.results.compute_closures_and_metrics()
 
         return self.results
 


### PR DESCRIPTION
This PR resolves an issue where evaluation metrics were not being correctly saved during the execution of the loop closure pipeline. Specifically, the method `self.results.compute_closures_and_metrics()` was being called after saving the configuration and logging, resulting in incomplete or missing evaluation metrics in the output file (`evaluation_metrics.txt`).

The change moves the `compute_closures_and_metrics()` method to be executed before the configuration is saved and the results are logged, ensuring that all metrics are correctly calculated and included in the output.

## Issue Details

Before this fix, running the pipeline with the command:

```bash
map_closure_pipeline -e --dataloader mulran ./data/MulRan/KAIST03/ ./output
```

produced an incomplete `evaluation_metrics.txt` file with no data:

```bash
+----------+----------------+-----------------+-----------------+-----------+--------+----------+
| #Inliers | True Positives | False Positives | False Negatives | Precision | Recall | F1 score |
+==========+================+=================+=================+===========+========+==========+

                                 Loop Closure Evaluation Metrics                                 
```

After the fix, the metrics are properly calculated and saved, as shown below:

```bash
+----------+----------------+-----------------+-----------------+-----------+--------+----------+
| #Inliers | True Positives | False Positives | False Negatives | Precision | Recall | F1 score |
+==========+================+=================+=================+===========+========+==========+
|    5     |     54062      |       502       |     1504324     | 0.9908    | 0.0347 | 0.0670   |
|    6     |     54062      |       502       |     1504324     | 0.9908    | 0.0347 | 0.0670   |
|    7     |     54062      |       502       |     1504324     | 0.9908    | 0.0347 | 0.0670   |
|    8     |     54062      |       502       |     1504324     | 0.9908    | 0.0347 | 0.0670   |
|    9     |     54062      |       502       |     1504324     | 0.9908    | 0.0347 | 0.0670   |
|    10    |     54062      |       502       |     1504324     | 0.9908    | 0.0347 | 0.0670   |
|    11    |     54062      |       502       |     1504324     | 0.9908    | 0.0347 | 0.0670   |
|    12    |     52302      |       16        |     1506084     | 0.9997    | 0.0336 | 0.0649   |
|    13    |     52302      |       16        |     1506084     | 0.9997    | 0.0336 | 0.0649   |
|    14    |     52302      |       16        |     1506084     | 0.9997    | 0.0336 | 0.0649   |
+----------+----------------+-----------------+-----------------+-----------+--------+----------+

                                 Loop Closure Evaluation Metrics                                 
```