### PR TITLE
remove strict requirement on kiss-icp version

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -11,7 +11,7 @@ authors = [{ name = "Saurabh Gupta" }, { name = "Tiziano Guadagnino" }]
 requires-python = ">=3.7"
 keywords = ["Loop Closures", "Localization", "SLAM", "LiDAR"]
 dependencies = [
-    "kiss-icp==1.0.0",
+    "kiss-icp>=1.0.0",
     "numpy<2.0.0",
     "pyquaternion",
     "pydantic>=2",


### PR DESCRIPTION
Make kiss-icp version requirement to >=1.0.0 instead of a strict ==1.0.0 in `pyproject.toml`