### PR TITLE
Fixes the missing artifacts

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -59,8 +59,9 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          name: artifact-*
           path: dist
+          merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
The upgrade to `actions/upload-artifact@v4` means that instead of one artifact with multiple files, we generate separate artifacts. 
As a reuslt, the `actions/download-artifact@v4` should also be looking for multiple files to download and publish to pypi