### PR TITLE
Fix Ground Alignment Indoors

### DIFF
--- a/cpp/map_closures/GroundAlign.cpp
+++ b/cpp/map_closures/GroundAlign.cpp
@@ -88,7 +88,9 @@ std::vector<Eigen::Vector3d> ComputeLowestPoints(const std::vector<Eigen::Vector
     std::for_each(pointcloud.cbegin(), pointcloud.cend(), [&](const Eigen::Vector3d &point) {
         auto pixel = PointToPixel(point);
         if (lowest_point_hash_map.find(pixel) == lowest_point_hash_map.cend()) {
-            lowest_point_hash_map.insert({pixel, point});
+            if (point.z() < 0) {
+                lowest_point_hash_map.insert({pixel, point});
+            }
         } else if (point.z() < lowest_point_hash_map[pixel].z()) {
             lowest_point_hash_map[pixel] = point;
         }


### PR DESCRIPTION
- Check if the computed lowest point in each column has its Z-coordinate below zero
- Not having this checks leads to wrong alignments indoors due to points recorded outside the windows where the ground is not necessarily visible (depending on the mounting position of the LiDAR)