### PR TITLE
Fix OpenCV third party build

### DIFF
--- a/cpp/3rdparty/opencv/opencv.cmake
+++ b/cpp/3rdparty/opencv/opencv.cmake
@@ -54,8 +54,7 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "CMake build type")
 
 message(STATUS "Fetching OpenCV from Github")
 include(FetchContent)
-FetchContent_Declare(opencv GIT_REPOSITORY https://github.com/opencv/opencv.git GIT_TAG 4.x
-                     GIT_SHALLOW TRUE GIT_PROGRESS TRUE)
+FetchContent_Declare(opencv URL https://github.com/opencv/opencv/archive/refs/tags/4.11.0.tar.gz)
 FetchContent_MakeAvailable(opencv)
 # OpenCV_INCLUDE_DIRS is set by OpenCVConfig.cmake and is unavailable after simply building
 set(OpenCV_INCLUDE_DIRS "${opencv_SOURCE_DIR}/include")


### PR DESCRIPTION
- We were using the 4.x tag for OpenCV `FetchContent` which is still under development
- Some new commits on their 4.x branch in the last week [broke our ci builds](https://github.com/PRBonn/MapClosures/actions/runs/13860998848/job/39543607568) which were [working fine until last week](https://github.com/PRBonn/MapClosures/actions/runs/13975557502)

- In this fix, we instead use a released tar.gz file for OpenCV `FetchContent` with version 4.11.0