### PR TITLE
Revert PR #60

### DIFF
--- a/cpp/map_closures/GroundAlign.cpp
+++ b/cpp/map_closures/GroundAlign.cpp
@@ -88,9 +88,7 @@ std::vector<Eigen::Vector3d> ComputeLowestPoints(const std::vector<Eigen::Vector
     std::for_each(pointcloud.cbegin(), pointcloud.cend(), [&](const Eigen::Vector3d &point) {
         const auto &pixel = PointToPixel(point);
         if (lowest_point_hash_map.find(pixel) == lowest_point_hash_map.cend()) {
-            if (point.z() < 0) {
-                lowest_point_hash_map.emplace(pixel, point);
-            }
+            lowest_point_hash_map.emplace(pixel, point);
         } else if (point.z() < lowest_point_hash_map[pixel].z()) {
             lowest_point_hash_map[pixel] = point;
         }


### PR DESCRIPTION
This reverts changes made in #60 for indoor environments as it breaks kiss-slam results in the paper.
Try this hack later, after making a release version for kiss-slam reproducibility.