### PR TITLE
Updated Ground Alignment and Add Local Map-Based Evaluation of Closures

### DIFF
--- a/cpp/map_closures/CMakeLists.txt
+++ b/cpp/map_closures/CMakeLists.txt
@@ -22,7 +22,7 @@
 # SOFTWARE.
 
 add_library(map_closures STATIC)
-target_sources(map_closures PRIVATE DensityMap.cpp AlignRansac2D.cpp GroundAlign.cpp
+target_sources(map_closures PRIVATE VoxelMap.cpp DensityMap.cpp AlignRansac2D.cpp GroundAlign.cpp
                                     MapClosures.cpp)
 target_include_directories(map_closures PUBLIC ${hbst_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(map_closures PUBLIC Eigen3::Eigen ${OpenCV_LIBS} Sophus::Sophus)

--- a/cpp/map_closures/DensityMap.hpp
+++ b/cpp/map_closures/DensityMap.hpp
@@ -38,7 +38,7 @@ struct DensityMap {
     DensityMap(DensityMap &&other) = default;
     DensityMap &operator=(DensityMap &&other) = default;
     DensityMap &operator=(const DensityMap &other) = delete;
-    inline uint8_t &operator()(const int x, const int y) { return grid.at<uint8_t>(x, y); }
+    uint8_t &operator()(const int x, const int y) { return grid.at<uint8_t>(x, y); }
     Eigen::Vector2i lower_bound;
     double resolution;
     cv::Mat grid;

--- a/cpp/map_closures/DensityMap.hpp
+++ b/cpp/map_closures/DensityMap.hpp
@@ -38,7 +38,7 @@ struct DensityMap {
     DensityMap(DensityMap &&other) = default;
     DensityMap &operator=(DensityMap &&other) = default;
     DensityMap &operator=(const DensityMap &other) = delete;
-    inline auto &operator()(const int x, const int y) { return grid.at<uint8_t>(x, y); }
+    inline uint8_t &operator()(const int x, const int y) { return grid.at<uint8_t>(x, y); }
     Eigen::Vector2i lower_bound;
     double resolution;
     cv::Mat grid;

--- a/cpp/map_closures/GroundAlign.cpp
+++ b/cpp/map_closures/GroundAlign.cpp
@@ -24,6 +24,8 @@
 #include "GroundAlign.hpp"
 
 #include <Eigen/Core>
+#include <Eigen/Eigenvalues>
+#include <Eigen/Geometry>
 #include <algorithm>
 #include <numeric>
 #include <sophus/se3.hpp>
@@ -39,14 +41,80 @@ struct PixelHash {
     }
 };
 
-void TransformPoints(const Sophus::SE3d &T, std::vector<Eigen::Vector3d> &pointcloud) {
+void TransformPoints(const Sophus::SE3d &T, Vector3dVector &pointcloud) {
     std::transform(pointcloud.cbegin(), pointcloud.cend(), pointcloud.begin(),
                    [&](const auto &point) { return T * point; });
 }
 
+struct VoxelMeanAndNormal {
+    Eigen::Vector3d mean;
+    Eigen::Vector3d normal;
+};
+
+auto PointToPixel = [](const Eigen::Vector3d &pt) -> Eigen::Vector2i {
+    return Eigen::Vector2i(static_cast<int>(std::floor(pt.x())),
+                           static_cast<int>(std::floor(pt.y())));
+};
+
+std::pair<Vector3dVector, Sophus::SE3d> SampleGroundPoints(const Vector3dVector &voxel_means,
+                                                           const Vector3dVector &voxel_normals) {
+    std::unordered_map<Eigen::Vector2i, VoxelMeanAndNormal, PixelHash> lowest_voxel_hash_map;
+
+    for (size_t index = 0; index < voxel_means.size(); ++index) {
+        const Eigen::Vector3d &mean = voxel_means[index];
+        const Eigen::Vector3d &normal = voxel_normals[index];
+        const Eigen::Vector2i pixel = PointToPixel(mean);
+
+        auto it = lowest_voxel_hash_map.find(pixel);
+        if (it == lowest_voxel_hash_map.end()) {
+            lowest_voxel_hash_map.emplace(pixel, VoxelMeanAndNormal{mean, normal});
+        } else if (mean.z() < it->second.mean.z()) {
+            it->second = VoxelMeanAndNormal{mean, normal};
+        }
+    }
+
+    std::vector<VoxelMeanAndNormal> low_lying_voxels(lowest_voxel_hash_map.size());
+    std::transform(lowest_voxel_hash_map.cbegin(), lowest_voxel_hash_map.cend(),
+                   low_lying_voxels.begin(), [](const auto &entry) { return entry.second; });
+
+    const Eigen::Matrix3d covariance_matrix =
+        std::transform_reduce(
+            low_lying_voxels.cbegin(), low_lying_voxels.cend(), Eigen::Matrix3d().setZero(),
+            std::plus<Eigen::Matrix3d>(),
+            [&](const auto &voxel) { return voxel.normal * voxel.normal.transpose(); }) /
+        static_cast<double>(low_lying_voxels.size() - 1);
+
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> eigensolver(covariance_matrix);
+    Eigen::Vector3d largest_eigenvector = eigensolver.eigenvectors().col(2);
+    largest_eigenvector =
+        (largest_eigenvector.z() < 0) ? -1.0 * largest_eigenvector : largest_eigenvector;
+    const Eigen::Vector3d axis = largest_eigenvector.cross(Eigen::Vector3d(0.0, 0.0, 1.0));
+    const double angle = std::acos(std::clamp(largest_eigenvector.z(), -1.0, 1.0));
+    const double axis_norm = axis.norm();
+
+    const Eigen::Matrix3d R = axis_norm > 1e-3
+                                  ? Eigen::AngleAxisd(angle, axis / axis_norm).toRotationMatrix()
+                                  : Eigen::Matrix3d::Identity();
+
+    Eigen::Vector3d ground_centroid(0.0, 0.0, 0.0);
+    Vector3dVector ground_samples;
+    ground_samples.reserve(low_lying_voxels.size());
+    std::for_each(low_lying_voxels.cbegin(), low_lying_voxels.cend(), [&](const auto &voxel) {
+        if (std::abs(voxel.normal.dot(largest_eigenvector)) > 0.95) {
+            ground_centroid += voxel.mean;
+            ground_samples.emplace_back(voxel.mean);
+        }
+    });
+    ground_samples.shrink_to_fit();
+    ground_centroid /= static_cast<double>(ground_samples.size());
+
+    const double z_shift = R.row(2) * ground_centroid;
+    const Sophus::SE3d T_init(R, Eigen::Vector3d(0.0, 0.0, -1.0 * z_shift));
+    return std::make_pair(ground_samples, T_init);
+}
+
 using LinearSystem = std::pair<Eigen::Matrix3d, Eigen::Vector3d>;
-LinearSystem BuildLinearSystem(const std::vector<Eigen::Vector3d> &points,
-                               const double resolution) {
+LinearSystem BuildLinearSystem(const Vector3dVector &points) {
     auto compute_jacobian_and_residual = [](const auto &point) {
         const double residual = point.z();
         Eigen::Matrix<double, 1, 3> J;
@@ -67,7 +135,7 @@ LinearSystem BuildLinearSystem(const std::vector<Eigen::Vector3d> &points,
                               LinearSystem(Eigen::Matrix3d::Zero(), Eigen::Vector3d::Zero()),
                               sum_linear_systems, [&](const auto &point) {
                                   const auto &[J, residual] = compute_jacobian_and_residual(point);
-                                  const double w = std::abs(residual) <= resolution ? 1.0 : 0.0;
+                                  const double w = std::exp(-1.0 * residual * residual);
                                   return LinearSystem(J.transpose() * w * J,          // JTJ
                                                       J.transpose() * w * residual);  // JTr
                               });
@@ -75,45 +143,21 @@ LinearSystem BuildLinearSystem(const std::vector<Eigen::Vector3d> &points,
 }
 
 static constexpr double convergence_threshold = 1e-3;
-static constexpr int max_iterations = 20;
-
-std::vector<Eigen::Vector3d> ComputeLowestPoints(const std::vector<Eigen::Vector3d> &pointcloud,
-                                                 const double resolution) {
-    std::unordered_map<Eigen::Vector2i, Eigen::Vector3d, PixelHash> lowest_point_hash_map;
-    auto PointToPixel = [&resolution](const Eigen::Vector3d &pt) -> Eigen::Vector2i {
-        return Eigen::Vector2i(static_cast<int>(std::floor(pt.x() / resolution)),
-                               static_cast<int>(std::floor(pt.y() / resolution)));
-    };
-
-    std::for_each(pointcloud.cbegin(), pointcloud.cend(), [&](const Eigen::Vector3d &point) {
-        const auto &pixel = PointToPixel(point);
-        if (lowest_point_hash_map.find(pixel) == lowest_point_hash_map.cend()) {
-            lowest_point_hash_map.emplace(pixel, point);
-        } else if (point.z() < lowest_point_hash_map[pixel].z()) {
-            lowest_point_hash_map[pixel] = point;
-        }
-    });
-
-    std::vector<Eigen::Vector3d> low_lying_points(lowest_point_hash_map.size());
-    std::transform(lowest_point_hash_map.cbegin(), lowest_point_hash_map.cend(),
-                   low_lying_points.begin(), [](const auto &entry) { return entry.second; });
-    return low_lying_points;
-}
+static constexpr int max_iterations = 10;
 }  // namespace
 
 namespace map_closures {
-Eigen::Matrix4d AlignToLocalGround(const std::vector<Eigen::Vector3d> &pointcloud,
-                                   const double resolution) {
-    Sophus::SE3d T = Sophus::SE3d(Eigen::Matrix3d::Identity(), Eigen::Vector3d::Zero());
-    auto low_lying_points = ComputeLowestPoints(pointcloud, resolution);
-
+Eigen::Matrix4d AlignToLocalGround(const Vector3dVector &voxel_means,
+                                   const Vector3dVector &voxel_normals) {
+    auto [ground_samples, T] = SampleGroundPoints(voxel_means, voxel_normals);
+    TransformPoints(T, ground_samples);
     for (int iters = 0; iters < max_iterations; iters++) {
-        const auto &[H, b] = BuildLinearSystem(low_lying_points, resolution);
+        const auto &[H, b] = BuildLinearSystem(ground_samples);
         const Eigen::Vector3d &dx = H.ldlt().solve(-b);
         Eigen::Matrix<double, 6, 1> se3 = Eigen::Matrix<double, 6, 1>::Zero();
         se3.block<3, 1>(2, 0) = dx;
         Sophus::SE3d estimation(Sophus::SE3d::exp(se3));
-        TransformPoints(estimation, low_lying_points);
+        TransformPoints(estimation, ground_samples);
         T = estimation * T;
         if (dx.norm() < convergence_threshold) break;
     }

--- a/cpp/map_closures/GroundAlign.hpp
+++ b/cpp/map_closures/GroundAlign.hpp
@@ -26,9 +26,7 @@
 #include <Eigen/Core>
 #include <vector>
 
-using Vector3dVector = std::vector<Eigen::Vector3d>;
-
 namespace map_closures {
-Eigen::Matrix4d AlignToLocalGround(const Vector3dVector &voxel_means,
-                                   const Vector3dVector &voxel_normals);
+Eigen::Matrix4d AlignToLocalGround(const std::vector<Eigen::Vector3d> &voxel_means,
+                                   const std::vector<Eigen::Vector3d> &voxel_normals);
 }  // namespace map_closures

--- a/cpp/map_closures/GroundAlign.hpp
+++ b/cpp/map_closures/GroundAlign.hpp
@@ -26,7 +26,9 @@
 #include <Eigen/Core>
 #include <vector>
 
+using Vector3dVector = std::vector<Eigen::Vector3d>;
+
 namespace map_closures {
-Eigen::Matrix4d AlignToLocalGround(const std::vector<Eigen::Vector3d> &pointcloud,
-                                   const double resolution);
+Eigen::Matrix4d AlignToLocalGround(const Vector3dVector &voxel_means,
+                                   const Vector3dVector &voxel_normals);
 }  // namespace map_closures

--- a/cpp/map_closures/VoxelMap.cpp
+++ b/cpp/map_closures/VoxelMap.cpp
@@ -1,0 +1,149 @@
+// MIT License
+
+// Copyright (c) 2025 Saurabh Gupta, Tiziano Guadagnino, Benedikt Mersch,
+// Niklas Trekel, Meher Malladi, and Cyrill Stachniss.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#include "VoxelMap.hpp"
+
+#include <Eigen/Core>
+#include <Eigen/Eigenvalues>
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <tuple>
+#include <vector>
+
+namespace {
+
+inline Voxel ToVoxelCoordinates(const Eigen::Vector3d &point, const double voxel_size) {
+    return Voxel(static_cast<int>(std::floor(point.x() / voxel_size)),
+                 static_cast<int>(std::floor(point.y() / voxel_size)),
+                 static_cast<int>(std::floor(point.z() / voxel_size)));
+}
+
+static constexpr unsigned int min_points_for_covariance_computation = 10;
+
+std::tuple<Eigen::Vector3d, Eigen::Vector3d> ComputeMeanAndNormal(
+    const map_closures::VoxelBlock &coordinates) {
+    const double num_points = static_cast<double>(coordinates.size());
+    const Eigen::Vector3d &mean =
+        std::reduce(coordinates.cbegin(), coordinates.cend(), Eigen::Vector3d().setZero()) /
+        num_points;
+
+    const Eigen::Matrix3d &covariance =
+        std::transform_reduce(coordinates.cbegin(), coordinates.cend(), Eigen::Matrix3d().setZero(),
+                              std::plus<Eigen::Matrix3d>(),
+                              [&mean](const Eigen::Vector3d &point) {
+                                  const Eigen::Vector3d &centered = point - mean;
+                                  const Eigen::Matrix3d S = centered * centered.transpose();
+                                  return S;
+                              }) /
+        (num_points - 1);
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver(covariance);
+    const Eigen::Vector3d normal = solver.eigenvectors().col(0);
+    return std::make_tuple(mean, normal);
+}
+
+}  // namespace
+
+namespace map_closures {
+void VoxelBlock::emplace_back(const Eigen::Vector3d &p) {
+    if (size() < max_points_per_normal_computation) {
+        points.at(num_points) = p;
+        ++num_points;
+    }
+}
+
+VoxelMap::VoxelMap(const double voxel_size, const double max_distance)
+    : voxel_size_(voxel_size),
+      map_resolution_(voxel_size /
+                      static_cast<double>(std::sqrt(max_points_per_normal_computation))),
+      max_distance_(max_distance) {}
+
+void VoxelMap::IntegrateFrame(const Vector3dVector &points, const Eigen::Matrix4d &pose) {
+    Vector3dVector points_transformed(points.size());
+    const auto &R = pose.block<3, 3>(0, 0);
+    const auto &t = pose.block<3, 1>(0, 3);
+    std::transform(points.cbegin(), points.cend(), points_transformed.begin(),
+                   [&](const auto &point) { return R * point + t; });
+    AddPoints(points_transformed);
+}
+
+void VoxelMap::AddPoints(const Vector3dVector &points) {
+    std::for_each(points.cbegin(), points.cend(), [&](const auto &point) {
+        const auto voxel = ToVoxelCoordinates(point, voxel_size_);
+        const auto &[it, inserted] = map_.insert({voxel, VoxelBlock()});
+        if (!inserted) {
+            const auto &voxel_points = it->second;
+            if (voxel_points.size() == max_points_per_normal_computation ||
+                std::any_of(voxel_points.cbegin(), voxel_points.cend(),
+                            [&](const auto &voxel_point) {
+                                return (voxel_point - point).norm() < map_resolution_;
+                            })) {
+                return;
+            }
+        }
+        it->second.emplace_back(point);
+    });
+}
+
+Vector3dVector VoxelMap::Pointcloud() const {
+    Vector3dVector points;
+    points.reserve(map_.size() * max_points_per_normal_computation);
+    std::for_each(map_.cbegin(), map_.cend(), [&](const auto &map_element) {
+        const auto &voxel_points = map_element.second;
+        std::for_each(voxel_points.cbegin(), voxel_points.cend(),
+                      [&](const auto &p) { points.emplace_back(p.template cast<double>()); });
+    });
+    points.shrink_to_fit();
+    return points;
+}
+
+std::tuple<Vector3dVector, Vector3dVector> VoxelMap::PerVoxelMeanAndNormal() const {
+    Vector3dVector voxel_means;
+    voxel_means.reserve(map_.size());
+    Vector3dVector voxel_normals;
+    voxel_normals.reserve(map_.size());
+    std::for_each(map_.cbegin(), map_.cend(), [&](const auto &inner_block) {
+        const auto &voxel_block = inner_block.second;
+        if (voxel_block.size() >= min_points_for_covariance_computation) {
+            const auto &[mean, normal] = ComputeMeanAndNormal(voxel_block);
+            voxel_means.emplace_back(mean);
+            voxel_normals.emplace_back(normal);
+        }
+    });
+    voxel_means.shrink_to_fit();
+    voxel_normals.shrink_to_fit();
+    return std::make_tuple(voxel_means, voxel_normals);
+}
+
+void VoxelMap::RemovePointsFarFromLocation(const Eigen::Vector3d &origin) {
+    const auto max_distance2 = max_distance_ * max_distance_;
+    for (auto it = map_.begin(); it != map_.end();) {
+        const auto &[voxel, voxel_points] = *it;
+        const auto &pt = voxel_points.front();
+        if ((pt - origin).squaredNorm() >= (max_distance2)) {
+            it = map_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+}  // namespace map_closures

--- a/cpp/map_closures/VoxelMap.cpp
+++ b/cpp/map_closures/VoxelMap.cpp
@@ -109,9 +109,8 @@ Vector3dVector VoxelMap::Pointcloud() const {
     points.reserve(map_.size() * max_points_per_normal_computation);
     std::for_each(map_.cbegin(), map_.cend(), [&](const auto &map_element) {
         const VoxelBlock &voxel_block = map_element.second;
-        std::for_each(voxel_block.cbegin(), voxel_block.cend(), [&](const Eigen::Vector3d &p) {
-            points.emplace_back(p.template cast<double>());
-        });
+        std::for_each(voxel_block.cbegin(), voxel_block.cend(),
+                      [&](const Eigen::Vector3d &p) { points.emplace_back(p); });
     });
     points.shrink_to_fit();
     return points;

--- a/cpp/map_closures/VoxelMap.hpp
+++ b/cpp/map_closures/VoxelMap.hpp
@@ -46,7 +46,7 @@ using Vector3dVector = std::vector<Eigen::Vector3d>;
 
 struct VoxelBlock {
     void emplace_back(const Eigen::Vector3d &point);
-    inline constexpr size_t size() const { return num_points; }
+    size_t size() const { return num_points; }
     auto cbegin() const { return points.cbegin(); }
     auto cend() const { return std::next(points.cbegin(), num_points); }
     Eigen::Vector3d front() const { return points.front(); }
@@ -57,9 +57,9 @@ struct VoxelBlock {
 struct VoxelMap {
     explicit VoxelMap(const double voxel_size, const double max_distance);
 
-    inline void Clear() { map_.clear(); }
-    inline bool Empty() const { return map_.empty(); }
-    inline size_t NumVoxels() const { return map_.size(); }
+    void Clear() { map_.clear(); }
+    bool Empty() const { return map_.empty(); }
+    size_t NumVoxels() const { return map_.size(); }
 
     void IntegrateFrame(const Vector3dVector &points, const Eigen::Matrix4d &pose);
     void AddPoints(const Vector3dVector &points);

--- a/cpp/map_closures/VoxelMap.hpp
+++ b/cpp/map_closures/VoxelMap.hpp
@@ -29,12 +29,9 @@
 #include <unordered_map>
 #include <vector>
 
-using Vector3dVector = std::vector<Eigen::Vector3d>;
-
-using Voxel = Eigen::Vector3i;
 template <>
-struct std::hash<Voxel> {
-    std::size_t operator()(const Voxel &voxel) const {
+struct std::hash<Eigen::Vector3i> {
+    std::size_t operator()(const Eigen::Vector3i &voxel) const {
         const uint32_t *vec = reinterpret_cast<const uint32_t *>(voxel.data());
         return (vec[0] * 73856093 ^ vec[1] * 19349669 ^ vec[2] * 83492791);
     }
@@ -44,13 +41,15 @@ struct std::hash<Voxel> {
 static constexpr unsigned int max_points_per_normal_computation = 20;
 
 namespace map_closures {
+using Voxel = Eigen::Vector3i;
+using Vector3dVector = std::vector<Eigen::Vector3d>;
 
 struct VoxelBlock {
     void emplace_back(const Eigen::Vector3d &point);
     inline constexpr size_t size() const { return num_points; }
     auto cbegin() const { return points.cbegin(); }
     auto cend() const { return std::next(points.cbegin(), num_points); }
-    auto front() const { return points.front(); }
+    Eigen::Vector3d front() const { return points.front(); }
     std::array<Eigen::Vector3d, max_points_per_normal_computation> points;
     size_t num_points = 0;
 };

--- a/cpp/map_closures/VoxelMap.hpp
+++ b/cpp/map_closures/VoxelMap.hpp
@@ -1,0 +1,77 @@
+// MIT License
+
+// Copyright (c) 2025 Saurabh Gupta, Tiziano Guadagnino, Benedikt Mersch,
+// Niklas Trekel, Meher Malladi, and Cyrill Stachniss.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#pragma once
+
+#include <Eigen/Core>
+#include <array>
+#include <cstdint>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+using Vector3dVector = std::vector<Eigen::Vector3d>;
+
+using Voxel = Eigen::Vector3i;
+template <>
+struct std::hash<Voxel> {
+    std::size_t operator()(const Voxel &voxel) const {
+        const uint32_t *vec = reinterpret_cast<const uint32_t *>(voxel.data());
+        return (vec[0] * 73856093 ^ vec[1] * 19349669 ^ vec[2] * 83492791);
+    }
+};
+
+// Same default as Open3d
+static constexpr unsigned int max_points_per_normal_computation = 20;
+
+namespace map_closures {
+
+struct VoxelBlock {
+    void emplace_back(const Eigen::Vector3d &point);
+    inline constexpr size_t size() const { return num_points; }
+    auto cbegin() const { return points.cbegin(); }
+    auto cend() const { return std::next(points.cbegin(), num_points); }
+    auto front() const { return points.front(); }
+    std::array<Eigen::Vector3d, max_points_per_normal_computation> points;
+    size_t num_points = 0;
+};
+
+struct VoxelMap {
+    explicit VoxelMap(const double voxel_size, const double max_distance);
+
+    inline void Clear() { map_.clear(); }
+    inline bool Empty() const { return map_.empty(); }
+    inline size_t NumVoxels() const { return map_.size(); }
+
+    void IntegrateFrame(const Vector3dVector &points, const Eigen::Matrix4d &pose);
+    void AddPoints(const Vector3dVector &points);
+
+    Vector3dVector Pointcloud() const;
+    std::tuple<Vector3dVector, Vector3dVector> PerVoxelMeanAndNormal() const;
+    void RemovePointsFarFromLocation(const Eigen::Vector3d &origin);
+
+    double voxel_size_;
+    double map_resolution_;
+    double max_distance_;
+    std::unordered_map<Voxel, VoxelBlock> map_;
+};
+}  // namespace map_closures

--- a/python/map_closures/map_closures.py
+++ b/python/map_closures/map_closures.py
@@ -27,6 +27,7 @@ from typing_extensions import TypeAlias
 
 from map_closures.config import MapClosuresConfig
 from map_closures.pybind import map_closures_pybind
+from map_closures.pybind.map_closures_pybind import _Vector3dVector as Vector3dVector
 
 ClosureCandidate: TypeAlias = map_closures_pybind._ClosureCandidate
 
@@ -36,29 +37,58 @@ class MapClosures:
         self._config = config
         self._pipeline = map_closures_pybind._MapClosures(self._config.model_dump())
 
-    def get_best_closure(self, query_idx: int, local_map: np.ndarray) -> ClosureCandidate:
-        pcd = map_closures_pybind._Vector3dVector(local_map)
-        closure = self._pipeline._GetBestClosure(query_idx, pcd)
+    def get_best_closure(
+        self,
+        query_idx: int,
+        local_map: np.ndarray,
+        voxel_means: np.ndarray,
+        voxel_normals: np.ndarray,
+    ) -> ClosureCandidate:
+        closure = self._pipeline._GetBestClosure(
+            query_idx,
+            Vector3dVector(local_map),
+            Vector3dVector(voxel_means),
+            Vector3dVector(voxel_normals),
+        )
         return closure
 
     def get_top_k_closures(
-        self, query_idx: int, local_map: np.ndarray, k: int
+        self,
+        query_idx: int,
+        local_map: np.ndarray,
+        voxel_means: np.ndarray,
+        voxel_normals: np.ndarray,
+        k: int,
     ) -> List[ClosureCandidate]:
-        pcd = map_closures_pybind._Vector3dVector(local_map)
-        top_k_closures = self._pipeline._GetTopKClosures(query_idx, pcd, k)
+        top_k_closures = self._pipeline._GetTopKClosures(
+            query_idx,
+            Vector3dVector(local_map),
+            Vector3dVector(voxel_means),
+            Vector3dVector(voxel_normals),
+            k,
+        )
         return top_k_closures
 
-    def get_closures(self, query_idx: int, local_map: np.ndarray) -> List[ClosureCandidate]:
-        pcd = map_closures_pybind._Vector3dVector(local_map)
-        closures = self._pipeline._GetClosures(query_idx, pcd)
+    def get_closures(
+        self,
+        query_idx: int,
+        local_map: np.ndarray,
+        voxel_means: np.ndarray,
+        voxel_normals: np.ndarray,
+    ) -> List[ClosureCandidate]:
+        closures = self._pipeline._GetClosures(
+            query_idx,
+            Vector3dVector(local_map),
+            Vector3dVector(voxel_means),
+            Vector3dVector(voxel_normals),
+        )
         return closures
 
     def get_density_map_from_id(self, map_id: int) -> np.ndarray:
         return self._pipeline._getDensityMapFromId(map_id)
 
+    def get_ground_alignment_from_id(self, map_id: int) -> np.ndarray:
+        return np.asarray(self._pipeline._getGroundAlignmentFromId(map_id))
 
-def align_map_to_local_ground(pointcloud, resolution):
-    return map_closures_pybind._align_map_to_local_ground(
-        map_closures_pybind._Vector3dVector(pointcloud),
-        resolution,
-    )
+    def save_hbst_database(self, database_path: str):
+        self._pipeline._SaveHbstDatabase(database_path)

--- a/python/map_closures/pipeline.py
+++ b/python/map_closures/pipeline.py
@@ -28,19 +28,14 @@ from typing import Optional
 import numpy as np
 from kiss_icp.config import KISSConfig
 from kiss_icp.kiss_icp import KissICP
-from kiss_icp.mapping import VoxelHashMap
 from tqdm.auto import trange
 
 from map_closures.config import load_config, write_config
 from map_closures.map_closures import MapClosures
-from map_closures.tools.evaluation import EvaluationPipeline, LocalMap, StubEvaluation
+from map_closures.tools.evaluation import EvaluationPipeline, StubEvaluation
+from map_closures.tools.utils import Data, pose_inv
 from map_closures.visualizer.visualizer import StubVisualizer, Visualizer
-
-
-def transform_points(pcd, T):
-    R = T[:3, :3]
-    t = T[:3, -1]
-    return pcd @ R.T + t
+from map_closures.voxel_map import VoxelMap
 
 
 class MapClosurePipeline:
@@ -71,37 +66,33 @@ class MapClosurePipeline:
         self.kiss_config.data.max_range = 100.0
         self.odometry = KissICP(self.kiss_config)
 
-        self.voxel_local_map = VoxelHashMap(
+        self.voxel_local_map = VoxelMap(
             voxel_size=self.closure_config.density_map_resolution,
             max_distance=self.kiss_config.data.max_range,
-            max_points_per_voxel=20,
         )
         self._map_range = self.kiss_config.data.max_range
 
-        self.closures = []
-        self.local_maps = []
-        self.density_maps = []
+        self.data = Data()
         self.odom_poses = np.zeros((self._n_scans, 4, 4))
 
-        self.closure_distance_threshold = 6.0
         self.results = StubEvaluation()
         if self._eval:
             gt_closures_path = (
-                os.path.join(self._dataset.sequence_dir, "loop_closure", "gt_closures.txt")
+                os.path.join(
+                    self._dataset.sequence_dir, "loop_closure", "local_map_gt_closures.txt"
+                )
                 if hasattr(self._dataset, "sequence_dir")
                 else None
             )
             if gt_closures_path is not None and os.path.exists(gt_closures_path):
                 self.gt_closures = np.loadtxt(gt_closures_path, dtype=int)
-                self.results = EvaluationPipeline(
-                    self.gt_closures, self._dataset_name, self.closure_distance_threshold
-                )
+                self.results = EvaluationPipeline(self.gt_closures, self._dataset_name)
 
         self.visualizer = Visualizer() if self._vis else StubVisualizer()
 
     def run(self):
         self._run_pipeline()
-        self.results.compute_closures_and_metrics()
+        self.results.compute_metrics()
         self._save_config()
         self._log_to_file()
         self._log_to_console()
@@ -110,76 +101,53 @@ class MapClosurePipeline:
 
     def _run_pipeline(self):
         map_idx = 0
-        poses_in_local_map = []
-        scan_indices_in_local_map = []
-
+        local_map_start_scan_idx = 0
         current_map_pose = np.eye(4)
+
         for scan_idx in trange(
             0,
             self._n_scans,
             ncols=8,
             unit=" frames",
             dynamic_ncols=True,
-            desc="Processing for Loop Closures",
+            desc="Processing Scans for Loop Closures",
         ):
             raw_frame, timestamps = self._dataset[scan_idx]
-            source, keypoints = self.odometry.register_frame(raw_frame, timestamps)
+            source, _ = self.odometry.register_frame(raw_frame, timestamps)
             self.odom_poses[scan_idx] = self.odometry.last_pose
             current_frame_pose = self.odometry.last_pose
 
-            frame_to_map_pose = np.linalg.inv(current_map_pose) @ current_frame_pose
-            self.voxel_local_map.add_points(transform_points(source, frame_to_map_pose))
+            frame_to_map_pose = pose_inv(current_map_pose) @ current_frame_pose
+            self.voxel_local_map.integrate_frame(source, frame_to_map_pose)
             self.visualizer.update_registration(
-                source,
-                self.odometry.local_map.point_cloud(),
-                current_frame_pose,
+                source, self.odometry.local_map.point_cloud(), current_frame_pose
             )
 
             if np.linalg.norm(frame_to_map_pose[:3, -1]) > self._map_range or (
                 scan_idx == self._n_scans - 1
             ):
                 local_map_pointcloud = self.voxel_local_map.point_cloud()
-                closures = self.map_closures.get_closures(map_idx, local_map_pointcloud)
-
-                scan_indices_in_local_map.append(scan_idx)
-                poses_in_local_map.append(current_frame_pose)
-
-                self.local_maps.append(
-                    LocalMap(
-                        local_map_pointcloud,
-                        self.map_closures.get_density_map_from_id(map_idx),
-                        np.copy(scan_indices_in_local_map),
-                        np.copy(poses_in_local_map),
-                    )
+                points, normals = self.voxel_local_map.per_voxel_mean_and_normal()
+                closures = self.map_closures.get_closures(
+                    map_idx, local_map_pointcloud, points, normals
                 )
-                self.visualizer.update_data(
-                    self.local_maps[-1].pointcloud,
-                    self.local_maps[-1].density_map,
-                    current_map_pose,
+
+                density_map = self.map_closures.get_density_map_from_id(map_idx)
+                self.data.append_localmap(
+                    local_map_pointcloud,
+                    density_map,
+                    self.map_closures.get_ground_alignment_from_id(map_idx),
+                    [local_map_start_scan_idx, scan_idx + 1],
                 )
+
+                self.visualizer.update_data(local_map_pointcloud, density_map, current_map_pose)
+
                 for closure in closures:
                     if closure.number_of_inliers > self.closure_config.inliers_threshold:
-                        reference_local_map = self.local_maps[closure.source_id]
-                        query_local_map = self.local_maps[closure.target_id]
-                        self.closures.append(
-                            np.r_[
-                                closure.source_id,
-                                closure.target_id,
-                                reference_local_map.scan_indices[0],
-                                query_local_map.scan_indices[0],
-                                closure.pose.flatten(),
-                            ]
+                        self.data.append_closure(closure)
+                        self.results.append(
+                            closure.source_id, closure.target_id, closure.number_of_inliers
                         )
-
-                        if self._eval:
-                            self.results.append(
-                                reference_local_map,
-                                query_local_map,
-                                closure.pose,
-                                self.closure_distance_threshold,
-                                closure.number_of_inliers,
-                            )
-
                         self.visualizer.update_closures(
                             np.asarray(closure.pose), [closure.source_id, closure.target_id]
                         )
@@ -187,24 +155,21 @@ class MapClosurePipeline:
                 self.voxel_local_map.remove_far_away_points(frame_to_map_pose[:3, -1])
                 pts_to_keep = self.voxel_local_map.point_cloud()
                 self.voxel_local_map.clear()
-                self.voxel_local_map.add_points(
-                    transform_points(
-                        pts_to_keep, np.linalg.inv(current_frame_pose) @ current_map_pose
-                    )
+                self.voxel_local_map.integrate_frame(
+                    pts_to_keep, pose_inv(current_frame_pose) @ current_map_pose
                 )
                 current_map_pose = np.copy(current_frame_pose)
-                scan_indices_in_local_map.clear()
-                poses_in_local_map.clear()
+                frame_to_map_pose = pose_inv(current_map_pose) @ current_frame_pose
+                local_map_start_scan_idx = scan_idx
                 map_idx += 1
 
-            scan_indices_in_local_map.append(scan_idx)
-            poses_in_local_map.append(current_frame_pose)
-
     def _log_to_file(self):
-        np.savetxt(os.path.join(self._results_dir, "map_closures.txt"), np.asarray(self.closures))
+        np.savetxt(
+            os.path.join(self._results_dir, "map_closures.txt"), np.asarray(self.data.closures)
+        )
         np.savetxt(
             os.path.join(self._results_dir, "kiss_poses_kitti.txt"),
-            np.asarray(self.odom_poses)[:, :3].reshape(-1, 12),
+            self.odom_poses[:, :3].reshape(-1, 12),
         )
         self.results.log_to_file(self._results_dir)
 
@@ -219,41 +184,14 @@ class MapClosurePipeline:
         table.add_column("# MapClosure", justify="left", style="cyan")
         table.add_column("Ref Map Index", justify="left", style="magenta")
         table.add_column("Query Map Index", justify="left", style="magenta")
-        table.add_column("Relative Translation 2D", justify="right", style="green")
-        table.add_column("Relative Rotation 2D", justify="right", style="green")
 
-        for i, closure in enumerate(self.closures):
-            table.add_row(
-                f"{i+1}",
-                f"{int(closure[0])}",
-                f"{int(closure[1])}",
-                f"[{closure[7]:.4f}, {closure[11]:.4f}] m",
-                f"{(np.arctan2(closure[8], closure[9]) * 180 / np.pi):.4f} deg",
-            )
+        for i, closure in enumerate(self.data.closures):
+            table.add_row(f"{i+1}", f"{int(closure[0])}", f"{int(closure[1])}")
         console.print(table)
 
     def _save_config(self):
         self._results_dir = self._create_results_dir()
         write_config(self.closure_config, os.path.join(self._results_dir, "config"))
-
-    def _write_data_to_disk(self):
-        import open3d as o3d
-        from matplotlib import pyplot as plt
-
-        local_map_dir = os.path.join(self._results_dir, "local_maps")
-        density_map_dir = os.path.join(self._results_dir, "density_maps")
-        os.makedirs(density_map_dir, exist_ok=True)
-        os.makedirs(local_map_dir, exist_ok=True)
-        for i, local_map in enumerate(self.local_maps):
-            plt.imsave(
-                os.path.join(density_map_dir, f"{i:06d}.png"),
-                255 - local_map.density_map,
-                cmap="gray",
-            )
-            o3d.io.write_point_cloud(
-                os.path.join(local_map_dir, f"{i:06d}.ply"),
-                o3d.geometry.PointCloud(o3d.utility.Vector3dVector(local_map.pointcloud)),
-            )
 
     def _create_results_dir(self) -> Path:
         def get_timestamp() -> str:
@@ -271,3 +209,20 @@ class MapClosurePipeline:
         os.symlink(results_dir, latest_dir)
 
         return results_dir
+
+    def write_data_to_disk(self):
+        import open3d as o3d
+        from matplotlib import pyplot as plt
+
+        local_map_dir = os.path.join(self._results_dir, "local_maps")
+        os.makedirs(local_map_dir, exist_ok=True)
+        density_map_dir = os.path.join(self._results_dir, "density_maps")
+        os.makedirs(density_map_dir, exist_ok=True)
+        for i, [local_map, density_map] in enumerate(
+            zip(self.data.local_maps, self.data.density_maps)
+        ):
+            o3d.io.write_point_cloud(
+                os.path.join(local_map_dir, f"{i:06d}.ply"),
+                o3d.geometry.PointCloud(o3d.utility.Vector3dVector(local_map)),
+            )
+            plt.imsave(os.path.join(density_map_dir, f"{i:06d}.png"), density_map, cmap="gray")

--- a/python/map_closures/tools/utils.py
+++ b/python/map_closures/tools/utils.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass, field
+from typing import List
+
+import numpy as np
+
+from map_closures.map_closures import ClosureCandidate
+
+
+def pose_inv(T):
+    T_inv = np.eye(4)
+    T_inv[:3, :3] = T[:3, :3].T
+    T_inv[:3, -1] = -T[:3, :3].T @ T[:3, -1]
+    return T_inv
+
+
+@dataclass
+class Data:
+    local_maps: list = field(default_factory=list)
+    density_maps: list = field(default_factory=list)
+    local_maps_scan_index_range: list = field(default_factory=list)
+    ground_alignment_transforms: list = field(default_factory=list)
+    closures: list = field(default_factory=list)
+
+    def append_localmap(
+        self,
+        local_map: np.ndarray,
+        density_map: np.ndarray,
+        ground_alignment_transform: np.ndarray,
+        scan_index_range: List[int],
+    ):
+        self.local_maps.append(local_map)
+        self.density_maps.append(density_map)
+        self.ground_alignment_transforms.append(ground_alignment_transform)
+        self.local_maps_scan_index_range.append(scan_index_range)
+
+    def append_closure(self, closure: ClosureCandidate):
+        self.closures.append(np.r_[closure.source_id, closure.target_id, closure.pose.flatten()])

--- a/python/map_closures/voxel_map.py
+++ b/python/map_closures/voxel_map.py
@@ -1,0 +1,55 @@
+# MIT License
+#
+# Copyright (c) 2025 Tiziano Guadagnino, Benedikt Mersch, Saurabh Gupta, Cyrill
+# Stachniss.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import numpy as np
+
+from map_closures.pybind import map_closures_pybind
+from map_closures.pybind.map_closures_pybind import _Vector3dVector as Vector3dVector
+
+
+class VoxelMap:
+    def __init__(self, voxel_size: float, max_distance: float):
+        self.map = map_closures_pybind._VoxelMap(voxel_size, max_distance)
+
+    def integrate_frame(self, points: np.ndarray, pose: np.ndarray):
+        vector3dvector = Vector3dVector(points.astype(np.float64))
+        self.map._integrate_frame(vector3dvector, pose)
+
+    def add_points(self, points: np.ndarray):
+        vector3dvector = Vector3dVector(points.astype(np.float64))
+        self.map._add_points(vector3dvector)
+
+    def point_cloud(self):
+        return np.asarray(self.map._point_cloud()).astype(np.float64)
+
+    def clear(self):
+        self.map._clear()
+
+    def num_voxels(self):
+        return self.map._num_voxels()
+
+    def remove_far_away_points(self, origin):
+        self.map._remove_far_away_points(origin)
+
+    def per_voxel_mean_and_normal(self):
+        means, normals = self.map._per_voxel_mean_and_normal()
+        return np.asarray(means, np.float64), np.asarray(normals, np.float64)


### PR DESCRIPTION
1. Add a normal-based filtering for better ground alignment for the BEV projections, this changes API call to the `get_closures` method
2. Use local map-based ground truth closures for the PR-curve evaluations, this changes API call to the `EvaluationPipeline` class and its methods
3. Minor changes in the data handling within the pipeline.py file