### PR TITLE
API to only match maps to existing database (no insertion) 

### DIFF
--- a/cpp/map_closures/MapClosures.hpp
+++ b/cpp/map_closures/MapClosures.hpp
@@ -90,6 +90,7 @@ public:
 
 protected:
     void MatchAndAddToDatabase(const int id, const std::vector<Eigen::Vector3d> &local_map);
+    void Match(const std::vector<Eigen::Vector3d> &local_map);
     ClosureCandidate ValidateClosure(const int reference_id, const int query_id) const;
 
     Config config_;


### PR DESCRIPTION
Feature request from #85, for use in localization mode, where one may not want to `pollute` the HBST database with features from the new query scan/map.

@Omega3395, I am adding this bare-minimum API call to the C++ library and will not provide extensive API support for other functionalities right away. You can use this in your fork temporarily while developing the peripheral APIs for your application around it.

We are developing a separate pipeline for localization and tracking to expand its use case. We will make a complete API release for that work later.