### PR TITLE
fix comparator for std::sort, follow strict weak ordering

### DIFF
--- a/cpp/map_closures/MapClosures.cpp
+++ b/cpp/map_closures/MapClosures.cpp
@@ -179,7 +179,7 @@ std::vector<ClosureCandidate> MapClosures::GetTopKClosures(
     const int query_id, const std::vector<Eigen::Vector3d> &local_map, const int k) {
     MatchAndAddToDatabase(query_id, local_map);
     auto compare_closure_candidates = [](const ClosureCandidate &a, const ClosureCandidate &b) {
-        return a.number_of_inliers >= b.number_of_inliers;
+        return a.number_of_inliers > b.number_of_inliers;
     };
 
     std::vector<ClosureCandidate> closures;


### PR DESCRIPTION
This pull request makes a small but important change to the sorting logic for closure candidates in the `MapClosures::GetTopKClosures` function. The comparison now uses strict greater-than (`>`) instead of greater-than-or-equal-to (`>=`), which ensures that closure candidates with the same number of inliers are not treated as interchangeable in the sort order. This  avoids weird, once in a million issue with std::sort that core dumps life.